### PR TITLE
Add removable persistent avspasering rows

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,15 +65,17 @@
             <tr>
               <th scope="col">Varighet avspasering</th>
               <th scope="col">Ferdig avspasert</th>
+              <th scope="col">Beskrivelse</th>
+              <th scope="col">
+                <span class="visually-hidden">Fjern rad</span>
+              </th>
             </tr>
           </thead>
-          <tbody>
-            <tr>
-              <td id="result-duration"></td>
-              <td id="result-end-time"></td>
-            </tr>
-          </tbody>
+          <tbody id="result-rows"></tbody>
         </table>
+        <p id="result-empty" class="result__empty">
+          Ingen lagrede avspaseringer ennå.
+        </p>
       </section>
     </main>
 

--- a/script.js
+++ b/script.js
@@ -4,18 +4,23 @@ const departureInput = document.getElementById("departure");
 const portionSelect = document.getElementById("portion");
 const errorMessage = document.getElementById("error-message");
 const resultSection = document.getElementById("result");
-const resultDuration = document.getElementById("result-duration");
-const resultEndTime = document.getElementById("result-end-time");
+const resultRows = document.getElementById("result-rows");
+const resultEmpty = document.getElementById("result-empty");
 const selectedFraction = document.getElementById("selected-fraction");
+
+const STORAGE_KEY = "avspaseringEntries";
+
+let entries = loadEntries();
 
 const dateTimeFormatter = new Intl.DateTimeFormat("no-NO", {
   dateStyle: "full",
   timeStyle: "short",
 });
 
+renderEntries();
+
 form.addEventListener("submit", (event) => {
   event.preventDefault();
-  hideResult();
   const arrivalValue = arrivalInput.value;
   const departureValue = departureInput.value;
 
@@ -48,21 +53,145 @@ form.addEventListener("submit", (event) => {
 
   const durationText = formatDuration(avspaseringMinutes);
   const completion = new Date(arrival.getTime() + avspaseringMinutes * 60000);
+  const fractionLabel =
+    portionSelect.options[portionSelect.selectedIndex].textContent;
 
-  selectedFraction.textContent = `Valgt andel: ${portionSelect.options[portionSelect.selectedIndex].text}`;
-  resultDuration.textContent = durationText;
-  resultEndTime.textContent = dateTimeFormatter.format(completion);
+  const newEntry = {
+    id: createId(),
+    duration: durationText,
+    completion: dateTimeFormatter.format(completion),
+    fractionLabel,
+    description: "",
+  };
+
+  entries.unshift(newEntry);
+  saveEntries();
+  renderEntries();
 
   errorMessage.textContent = "";
-  resultSection.hidden = false;
+  form.reset();
 });
-
-function hideResult() {
-  resultSection.hidden = true;
-}
 
 function showError(message) {
   errorMessage.textContent = message;
+}
+
+function renderEntries() {
+  resultRows.innerHTML = "";
+  const hasEntries = entries.length > 0;
+
+  resultSection.hidden = false;
+  resultEmpty.hidden = hasEntries;
+
+  if (!hasEntries) {
+    selectedFraction.textContent = "";
+    return;
+  }
+
+  entries.forEach((entry) => {
+    const row = document.createElement("tr");
+    row.dataset.id = entry.id;
+
+    const durationCell = document.createElement("td");
+    durationCell.textContent = entry.duration;
+
+    const completionCell = document.createElement("td");
+    completionCell.textContent = entry.completion;
+
+    const descriptionCell = document.createElement("td");
+    const descriptionInput = document.createElement("input");
+    descriptionInput.type = "text";
+    descriptionInput.placeholder = "Beskriv avspaseringen";
+    descriptionInput.value = entry.description || "";
+    descriptionInput.classList.add("result__description-input");
+    descriptionInput.addEventListener("input", () => {
+      entry.description = descriptionInput.value;
+      saveEntries();
+    });
+    descriptionCell.append(descriptionInput);
+
+    const actionsCell = document.createElement("td");
+    actionsCell.classList.add("result__actions");
+    const removeButton = document.createElement("button");
+    removeButton.type = "button";
+    removeButton.classList.add("result__remove-button");
+    removeButton.setAttribute("aria-label", "Fjern rad");
+    removeButton.textContent = "×";
+    removeButton.addEventListener("click", () => {
+      removeEntry(entry.id);
+    });
+    actionsCell.append(removeButton);
+
+    row.append(durationCell, completionCell, descriptionCell, actionsCell);
+    resultRows.append(row);
+  });
+
+  if (entries[0].fractionLabel) {
+    selectedFraction.textContent = `Valgt andel: ${entries[0].fractionLabel}`;
+  } else {
+    selectedFraction.textContent = "";
+  }
+}
+
+function removeEntry(id) {
+  entries = entries.filter((entry) => entry.id !== id);
+  saveEntries();
+  renderEntries();
+}
+
+function saveEntries() {
+  if (typeof localStorage === "undefined") {
+    return;
+  }
+
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+  } catch (error) {
+    // Ignorer lagringsfeil, for eksempel når lagring er deaktivert.
+  }
+}
+
+function loadEntries() {
+  if (typeof localStorage === "undefined") {
+    return [];
+  }
+
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+
+    if (!stored) {
+      return [];
+    }
+
+    const parsed = JSON.parse(stored);
+
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    return parsed
+      .map((entry) => ({
+        id: typeof entry.id === "string" ? entry.id : createId(),
+        duration: typeof entry.duration === "string" ? entry.duration : "",
+        completion:
+          typeof entry.completion === "string" ? entry.completion : "",
+        fractionLabel:
+          typeof entry.fractionLabel === "string" ? entry.fractionLabel : "",
+        description:
+          typeof entry.description === "string" ? entry.description : "",
+      }))
+      .filter((entry) => entry.duration && entry.completion);
+  } catch (error) {
+    return [];
+  }
+}
+
+function createId() {
+  if (window.crypto && typeof window.crypto.randomUUID === "function") {
+    return window.crypto.randomUUID();
+  }
+
+  return `id-${Date.now()}-${Math.random().toString(16).slice(2)}`;
 }
 
 function formatDuration(totalMinutes) {

--- a/styles.css
+++ b/styles.css
@@ -15,6 +15,18 @@
   box-sizing: border-box;
 }
 
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 body {
   margin: 0;
   min-height: 100vh;
@@ -179,6 +191,10 @@ select {
   background-color: rgba(255, 255, 255, 0.85);
 }
 
+.result__table td {
+  vertical-align: top;
+}
+
 .result__table thead {
   background: rgba(37, 99, 235, 0.1);
   color: var(--accent-hover);
@@ -189,6 +205,60 @@ select {
 
 .result__table tbody tr + tr td {
   border-top: 1px solid var(--border);
+}
+
+.result__table th:last-child,
+.result__table td:last-child {
+  text-align: center;
+  width: 3.5rem;
+}
+
+.result__description-input {
+  width: 100%;
+  font: inherit;
+  padding: 0.65rem 0.75rem;
+  border: 1px solid var(--border);
+  border-radius: 0.6rem;
+  background: rgba(255, 255, 255, 0.95);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.result__description-input:focus {
+  border-color: var(--accent);
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+}
+
+.result__actions {
+  text-align: center;
+}
+
+.result__remove-button {
+  background: none;
+  border: none;
+  color: var(--error);
+  font-size: 1.35rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0.25rem;
+  border-radius: 999px;
+  transition: background-color 0.2s ease, transform 0.2s ease;
+}
+
+.result__remove-button:hover,
+.result__remove-button:focus-visible {
+  background-color: rgba(200, 30, 30, 0.12);
+  outline: none;
+}
+
+.result__remove-button:active {
+  transform: scale(0.92);
+}
+
+.result__empty {
+  margin-top: 1rem;
+  color: rgba(31, 41, 51, 0.7);
+  font-style: italic;
 }
 
 .app__footer {


### PR DESCRIPTION
## Summary
- expand the result table to support multiple saved avspasering entries with removable rows and per-row descriptions
- persist calculated entries and descriptions in localStorage so they reappear on reload
- style the new description inputs and remove buttons to match the existing design

## Testing
- Manual: Verified adding an avspasering entry, editing its description, persisting after reload, and removing it

------
https://chatgpt.com/codex/tasks/task_e_68ced33e120883269c46f1b459499c07