### PR TITLE
Add screenshot capture for result rows

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,7 +63,10 @@
               <th scope="col">Varighet avspasering</th>
               <th scope="col">Ferdig avspasert</th>
               <th scope="col">Beskrivelse</th>
-              <th scope="col">
+              <th scope="col" class="result__column--screenshot">
+                <span class="visually-hidden">Lagre skjermbilde</span>
+              </th>
+              <th scope="col" class="result__column--actions">
                 <span class="visually-hidden">Fjern rad</span>
               </th>
             </tr>
@@ -80,6 +83,7 @@
       <p>Laget for enkel planlegging av avspasering.</p>
     </footer>
 
+    <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
     <script src="script.js"></script>
   </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -208,10 +208,51 @@ select {
   border-top: 1px solid var(--border);
 }
 
-.result__table th:last-child,
-.result__table td:last-child {
+.result__column--screenshot,
+.result__column--actions,
+.result__screenshot,
+.result__actions {
+  width: 3.75rem;
   text-align: center;
-  width: 3.5rem;
+}
+
+.result__screenshot,
+.result__actions {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.result__actions {
+  gap: 0.35rem;
+}
+
+.result__screenshot-button {
+  background: none;
+  border: none;
+  color: var(--accent);
+  font-size: 1.35rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0.25rem;
+  border-radius: 999px;
+  transition: background-color 0.2s ease, transform 0.2s ease,
+    color 0.2s ease;
+}
+
+.result__screenshot-button:hover,
+.result__screenshot-button:focus-visible {
+  background-color: rgba(37, 99, 235, 0.15);
+  outline: none;
+}
+
+.result__screenshot-button:active {
+  transform: scale(0.95);
+}
+
+.result__screenshot-button:disabled {
+  color: rgba(37, 99, 235, 0.45);
+  cursor: progress;
 }
 
 .result__description-input {
@@ -254,6 +295,75 @@ select {
 
 .result__remove-button:active {
   transform: scale(0.92);
+}
+
+.screenshot-card {
+  position: fixed;
+  inset: -9999px auto auto -9999px;
+  width: min(520px, calc(100vw - 2rem));
+  padding: 2.5rem 2.75rem;
+  border-radius: 24px;
+  background: linear-gradient(135deg, #eef4ff 0%, #ffffff 45%, #dbeafe 100%);
+  color: #111827;
+  box-shadow: 0 35px 70px -40px rgba(37, 99, 235, 0.5);
+  border: 1px solid rgba(37, 99, 235, 0.15);
+  font-family: inherit;
+}
+
+.screenshot-card__title {
+  margin: 0 0 0.75rem;
+  font-size: 1.6rem;
+  letter-spacing: 0.02em;
+}
+
+.screenshot-card__fraction {
+  margin: 0 0 1.25rem;
+  font-weight: 600;
+  color: #1d4ed8;
+}
+
+.screenshot-card__list {
+  margin: 0;
+  display: grid;
+  gap: 0.9rem;
+}
+
+.screenshot-card__item {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 0.35rem;
+  padding: 0.85rem 1rem;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.65);
+  border: 1px solid rgba(37, 99, 235, 0.18);
+}
+
+.screenshot-card__item dt {
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  font-size: 0.7rem;
+  color: rgba(37, 99, 235, 0.85);
+}
+
+.screenshot-card__item dd {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.screenshot-card__description {
+  margin: 1.5rem 0 0.75rem;
+  padding: 1rem 1.2rem;
+  background: rgba(255, 255, 255, 0.8);
+  border-radius: 16px;
+  border: 1px solid rgba(37, 99, 235, 0.12);
+}
+
+.screenshot-card__timestamp {
+  margin: 0;
+  text-align: right;
+  font-size: 0.85rem;
+  color: rgba(17, 24, 39, 0.7);
 }
 
 .result__empty {
@@ -351,6 +461,14 @@ select {
   .result__table td:last-child {
     text-align: left;
     width: auto;
+  }
+
+  .result__screenshot {
+    display: grid;
+  }
+
+  .result__screenshot-button {
+    justify-self: flex-end;
   }
 
   .result__actions {


### PR DESCRIPTION
## Summary
- add a screenshot column with capture button in the results table and load html2canvas
- generate a styled card for each entry and export it as a downloadable PNG
- style the new controls and exported card to match the app aesthetic

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cfc9dadcb08326b5bf126f848a9839